### PR TITLE
doc mods that should NOT build

### DIFF
--- a/doc/source/master_list.bib
+++ b/doc/source/master_list.bib
@@ -867,7 +867,7 @@
   title = "{Quality control for community-based sea-ice model development}",
   journal = PTRSA,
   year = {2018},
-  volume = {376},
+  volume = {376}
   url = {http://dx.doi.org/10.1098/rsta.2017.0344}
 }
 %  **********************************************


### PR DESCRIPTION
Testing a /doc/ *rst mod that **should** break documentation. Want to see how RTD bot works in a PR.