### PR TITLE
mods not in doc dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Original CICE badge
 [![Documentation Status](https://readthedocs.org/projects/cice-consortium-cice/badge/?version=master)](http://cice-consortium-cice.readthedocs.io/en/master/?badge=master)
 
 ## Overview
+TEST TEST TEST CHANGES HERE
+
 This repository contains the files and code needed to run the CICE sea ice numerical model starting with version 6. CICE is maintained by the CICE Consortium. Versions prior to v6 are found in the [CICE-svn-trunk repository](https://github.com/CICE-Consortium/CICE-svn-trunk).
 
 CICE consists of a top level driver and dynamical core plus the Icepack column physics code, which is included in CICE as a git submodule.  Because Icepack is a submodule of CICE, Icepack and CICE development are handled independently with respect to the github repositories even though development and testing may be done together. 


### PR DESCRIPTION
Testing a mod that **does not** affect /doc dir. Want to see how RTD bot works in a PR.